### PR TITLE
Replace broken README example with working example

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,11 +27,13 @@ import numpy as np
 
 from tpe.optimizer import TPEOptimizer
 
-def sphere(eval_config: Dict[str, float]) -> Tuple[float, float]:
+
+def sphere(eval_config: Dict[str, float]) -> Tuple[Dict[str, float], float]:
     start = time.time()
     vals = np.array(list(eval_config.values()))
     vals *= vals
     return {"loss": np.sum(vals)}, time.time() - start
+
 
 if __name__ == "__main__":
     dim = 10
@@ -39,7 +41,8 @@ if __name__ == "__main__":
     for d in range(dim):
         cs.add_hyperparameter(CSH.UniformFloatHyperparameter(f"x{d}", lower=-5, upper=5))
 
-    opt = TPEOptimizer(obj_func=sphere, config_space=cs, min_bandwidth_factor=1e-2, resultfile="sphere")
+    opt = TPEOptimizer(obj_func=sphere, config_space=cs, resultfile='sphere')
+    # If you do not want to do logging, remove the `logger_name` argument
     print(opt.optimize(logger_name="sphere"))
 ```
 

--- a/README.md
+++ b/README.md
@@ -17,30 +17,30 @@ pip install tpe
 The optimization of 10D sphere function can be executed as follows:
 
 ```python
-from typing import Dict
+import time
+from typing import Dict, Tuple
 
 import ConfigSpace as CS
 import ConfigSpace.hyperparameters as CSH
+
 import numpy as np
 
 from tpe.optimizer import TPEOptimizer
 
-
-def sphere(eval_config: Dict[str, float]) -> float:
+def sphere(eval_config: Dict[str, float]) -> Tuple[float, float]:
+    start = time.time()
     vals = np.array(list(eval_config.values()))
     vals *= vals
-    return np.sum(vals)
+    return {"loss": np.sum(vals)}, time.time() - start
 
-
-if __name__ == '__main__':
+if __name__ == "__main__":
     dim = 10
     cs = CS.ConfigurationSpace()
     for d in range(dim):
-        cs.add_hyperparameter(CSH.UniformFloatHyperparameter(f'x{d}', lower=-5, upper=5))
+        cs.add_hyperparameter(CSH.UniformFloatHyperparameter(f"x{d}", lower=-5, upper=5))
 
-    opt = TPEOptimizer(obj_func=sphere, config_space=cs, resultfile='sphere')
-    # If you do not want to do logging, remove the `logger_name` argument
-    opt.optimize(logger_name="sphere")
+    opt = TPEOptimizer(obj_func=sphere, config_space=cs, min_bandwidth_factor=1e-2, resultfile="sphere")
+    print(opt.optimize(logger_name="sphere"))
 ```
 
 The documentation of `ConfigSpace` is available [here](https://automl.github.io/ConfigSpace/master/).

--- a/README.md
+++ b/README.md
@@ -17,8 +17,9 @@ pip install tpe
 The optimization of 10D sphere function can be executed as follows:
 
 ```python
+from __future__ import annotations
+
 import time
-from typing import Dict, Tuple
 
 import ConfigSpace as CS
 import ConfigSpace.hyperparameters as CSH

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ import numpy as np
 from tpe.optimizer import TPEOptimizer
 
 
-def sphere(eval_config: Dict[str, float]) -> Tuple[Dict[str, float], float]:
+def sphere(eval_config: dict[str, float]) -> tuple[dict[str, float], float]:
     start = time.time()
     vals = np.array(list(eval_config.values()))
     vals *= vals

--- a/examples/example_sphere.py
+++ b/examples/example_sphere.py
@@ -9,7 +9,7 @@ import numpy as np
 from tpe.optimizer import TPEOptimizer
 
 
-def sphere(eval_config: Dict[str, float]) -> Tuple[float, float]:
+def sphere(eval_config: Dict[str, float]) -> Tuple[Dict[str, float], float]:
     start = time.time()
     vals = np.array(list(eval_config.values()))
     vals *= vals


### PR DESCRIPTION
The existing example shown in the README is broken because the objective function only returns a value.

tpe/examples/example_sphere.py works, because the objective function returns the expected result keys and runtime. So I just copy pasted the example_sphere_code into the readme.

I also corrected a mistake with the return type signature in tpe/examples/example_sphere.py